### PR TITLE
Modify cho2/productinfo/go/README.md: Delete -i flag in go build command

### DIFF
--- a/ch02/productinfo/go/README.md
+++ b/ch02/productinfo/go/README.md
@@ -5,7 +5,7 @@
 In order to build, Go to ``Go`` module root directory location (productinfo/go/server) and execute the following
  shell command,
 ```
-go build -i -v -o bin/server
+go build -v -o bin/server
 ```
 
 In order to run, Go to ``Go`` module root directory location (productinfo/go/server) and execute the following


### PR DESCRIPTION
The -i flag is deprecated from Go 1.6 release.

https://golang.org/doc/go1.16#:~:text=The%20%2Di%20flag%20accepted%20by,named%20on%20the%20command%20line.